### PR TITLE
Move more heex to components

### DIFF
--- a/lib/pomodoro_web/components/custom_components.ex
+++ b/lib/pomodoro_web/components/custom_components.ex
@@ -7,7 +7,7 @@ defmodule PomodoroWeb.CustomComponents do
 
   def header(assigns) do
     ~H"""
-     <section class="flex justify-center mr-0">
+     <section class="mr-0">
       <h1 class="text-4xl md:text-6xl lg:text-8xl font-bold">
        {render_slot(@inner_block)}
       </h1>
@@ -15,16 +15,42 @@ defmodule PomodoroWeb.CustomComponents do
     """
   end
 
+  attr :src, :string, required: true
+  attr :alt, :string, default: ""
+
+  def image(assigns) do
+    ~H"""
+    <section class="flex justify-center mt-20 mb-20">
+      <img class="object-scale-down h-52" src={@src} alt={@alt} />
+    </section>
+    """
+  end
+
+  attr :remaining_time, :atom, required: true
+
+  def timer_text(assigns) do
+    ~H"""
+    <section>
+      <h2  class="text-2xl md:text-2xl lg:text-2xl font-bold mb-20" >
+      <%= cond do %>
+        <% @remaining_time > 0 -> %> Remaining Time: {Timer.format_time(@remaining_time)}
+        <% true -> %> Expired!
+      <% end %>
+      </h2>
+    </section>
+    """
+  end
+
   def timer_select(assigns) do
     ~H"""
-     <div>
-       <form phx-change="set-timer">
-         <select name="timer" class="border-2 border-gray-300 bg-red-600 text-white m-1 p-3" id="">
-            <option value="" disabled selected>Select Timer</option>
-            <option :for={ {text, value} <- Timer.timer_opts()} value={value}> { text } </option>
-         </select>
-       </form>
-     </div>
+     <section>
+        <form phx-change="set-timer">
+          <select name="timer" class="border-2 border-gray-300 bg-red-600 text-white m-1 p-3" id="">
+              <option value="" disabled selected>Select Timer</option>
+              <option :for={ {text, value} <- Timer.timer_opts()} value={value}> { text } </option>
+          </select>
+        </form>
+    </section>
     """
   end
 end

--- a/lib/pomodoro_web/live/pomodoro_live.ex
+++ b/lib/pomodoro_web/live/pomodoro_live.ex
@@ -12,7 +12,8 @@ defmodule PomodoroWeb.PomodoroLive do
     socket =
       socket
       |> assign_new(:timer, fn -> @ten_minutes end)
-      |> assign_new(:remaining_time, fn -> @ten_minutes end)
+      |> assign_new(:remaining_time, fn -> @ten_seconds end)
+      # |> assign_new(:remaining_time, fn -> @ten_minutes end)
       |> assign_new(:timer_opts, fn -> timer_opts() end)
 
     if connected?(socket), do: count_down_timer()
@@ -22,24 +23,14 @@ defmodule PomodoroWeb.PomodoroLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class={["h-lvh",
+    <div class={["h-lvh text-center",
         @remaining_time > 0 && "bg-green-400 w-screen",
         @remaining_time <= 0 && "bg-red-400 w-screen"
     ]}>
       <CustomComponents.header> Pomodoro Timer </CustomComponents.header>
-      <section class="flex justify-center mt-20 mb-20">
-        <img class="object-scale-down h-52" src="/images/timer.png" alt="" />
-      </section>
-
-      <section class="text-center">
-        <h2  class="text-2xl md:text-2xl lg:text-2xl font-bold mb-20" >
-        <%= cond do %>
-          <% @remaining_time > 0 -> %> Remaining Time: {format_time(@remaining_time)}
-          <% true -> %> Expired!
-        <% end %>
-        </h2>
-        <CustomComponents.timer_select />
-      </section>
+      <CustomComponents.image src="/images/timer.png" alt=""/>
+      <CustomComponents.timer_text remaining_time={@remaining_time} />
+      <CustomComponents.timer_select />
     </div>
     """
   end

--- a/test/pomodoro_web/controllers/page_controller_test.exs
+++ b/test/pomodoro_web/controllers/page_controller_test.exs
@@ -10,15 +10,21 @@ defmodule PomodoroWeb.PageControllerTest do
 
     test "starts a new pomodoro timer", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/")
-      assert render(view) =~ "<span> Remaining Time: </span> 10 minutes"
+
+      assert render(view) =~
+               "<h2 class=\"text-2xl md:text-2xl lg:text-2xl font-bold mb-20\">\n   Remaining Time: 10 seconds\n    \n  </h2>"
     end
 
     test "change timer starts a new pomodoro timer", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/")
-      assert render(view) =~ "<span> Remaining Time: </span> 10 minutes"
 
-      assert view |> element("form")
-          |> render_change(%{"timer" => 25 * 60 }) =~ "<span> Remaining Time: </span> 25 minutes"
+      assert render(view) =~
+               "<h2 class=\"text-2xl md:text-2xl lg:text-2xl font-bold mb-20\">\n   Remaining Time: 10 seconds\n    \n  </h2>"
+
+      assert view
+             |> element("form")
+             |> render_change(%{"timer" => 25 * 60}) =~
+               "<h2 class=\"text-2xl md:text-2xl lg:text-2xl font-bold mb-20\">\n   Remaining Time: 25 minutes\n    \n  </h2>"
     end
   end
 end


### PR DESCRIPTION
Refactor the PomodoroLive and CustomComponents modules 

Update tests to reflect changes in the timer functionality and ensure accurate rendering of remaining time.